### PR TITLE
Nix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /data/output
 
 .DS_Store
+*~

--- a/README.md
+++ b/README.md
@@ -48,7 +48,43 @@ or just install from git:
 cargo install --git https://github.com/wjwei-handsome/wgatools.git
 ```
 
-### Usages
+#### Nix
+
+A nix flake is also available. You can build from within the repo like this:
+
+```shell
+nix build .#wgatools
+```
+
+Or directly install from github:
+
+```shell
+nix profile install github:wjwei-handsome/wgatools
+```
+
+#### Docker and Singularity
+
+Using nix, we can derive docker and singularity images:
+
+```shell
+nix build .#dockerImage
+```
+
+First, we load the docker image into the local daemon:
+
+```shell
+docker load < result
+```
+
+It's then possible to pack up a singularity image:
+
+```shell
+singularity build wgatools-$(git log -1 --format=%h --abbrev=8).sif docker-daemon://wgatools:latest
+```
+
+This can be useful when running on HPCs where it might be difficult to build wgatools.
+
+### Usage
 
 ```shell
 > wgatools

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1705883077,
+        "narHash": "sha256-ByzHHX3KxpU1+V0erFy8jpujTufimh6KaS/Iv3AciHk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5f5210aa20e343b7e35f40c033000db0ef80d7b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }: 
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        rustPackage = pkgs.rustPlatform.buildRustPackage {
+          name = "wgatools";
+          src = self;
+          cargoSha256 = "0000000000000000000000000000000000000000000000000000";
+        };
+        dockerImage = pkgs.dockerTools.buildImage {
+          name = "wgatools";
+          tag = "latest";
+          contents = [ rustPackage ];
+        };
+      in {
+        packages = {
+          inherit rustPackage;
+        };
+        defaultPackage = {
+          inherit rustPackage;
+        };
+        devShells.default = pkgs.mkShell {
+          buildInputs = [ pkgs.rustc pkgs.cargo ];
+        };
+        dockerImage = {
+          inherit dockerImage;
+        };
+        // Add the Singularity image here
+        singularityImage = {
+          inherit singularityImage;
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -20,11 +20,15 @@
         dockerImage = pkgs.dockerTools.buildImage {
           name = "wgatools";
           tag = "latest";
-          contents = [ rustPackage ];
+          copyToRoot = pkgs.buildEnv {
+              name = "docker-root";
+              paths = [ rustPackage ];
+          };
         };
       in {
         packages = {
           wgatools = rustPackage;
+          dockerImage = dockerImage;
         };
         defaultPackage = {
           x86_64-linux = rustPackage;

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
           version = "0.0";
           src = self;
           cargoSha256 = "sha256-WvBJMBncDYaom54CJpxPU0805CKaYO8TXiSqxFAWKsg=";
-          nativeBuildInputs = [ pkgs.cmake pkgs.pkg-config pkgs.openssl ];
+          nativeBuildInputs = [ pkgs.cmake pkgs.pkg-config pkgs.openssl pkgs.perl ];
         };
         dockerImage = pkgs.dockerTools.buildImage {
           name = "wgatools";

--- a/flake.nix
+++ b/flake.nix
@@ -4,16 +4,17 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }: 
+  outputs = { self, nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
         };
         rustPackage = pkgs.rustPlatform.buildRustPackage {
-          name = "wgatools";
+          pname = "wgatools";
+          version = "1.0";  // Replace with your package's version
           src = self;
-          cargoSha256 = "0000000000000000000000000000000000000000000000000000";
+          cargoSha256 = "0000000000000000000000000000000000000000000000000000"; // Replace after the first build attempt
         };
         dockerImage = pkgs.dockerTools.buildImage {
           name = "wgatools";
@@ -22,10 +23,10 @@
         };
       in {
         packages = {
-          inherit rustPackage;
+          wgatools = rustPackage;
         };
         defaultPackage = {
-          inherit rustPackage;
+          x86_64-linux = rustPackage;
         };
         devShells.default = pkgs.mkShell {
           buildInputs = [ pkgs.rustc pkgs.cargo ];

--- a/flake.nix
+++ b/flake.nix
@@ -33,10 +33,6 @@
         dockerImage = {
           inherit dockerImage;
         };
-        // Add the Singularity image here
-        singularityImage = {
-          inherit singularityImage;
-        };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,9 +12,10 @@
         };
         rustPackage = pkgs.rustPlatform.buildRustPackage {
           pname = "wgatools";
-          version = "1.0";  // Replace with your package's version
+          version = "0.0";
           src = self;
-          cargoSha256 = "0000000000000000000000000000000000000000000000000000"; // Replace after the first build attempt
+          cargoSha256 = "sha256-WvBJMBncDYaom54CJpxPU0805CKaYO8TXiSqxFAWKsg=";
+          nativeBuildInputs = [ pkgs.cmake pkgs.pkg-config pkgs.openssl ];
         };
         dockerImage = pkgs.dockerTools.buildImage {
           name = "wgatools";


### PR DESCRIPTION
This adds a nix flake file with documentation about how to use it to build wgatools and make docker and singularity images from it for distribution.