### PR TITLE
add gzip/xz/bzip2 support for IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,9 +465,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1620,10 +1630,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
+ "bzip2",
  "clap",
  "clap_complete",
  "crossterm",
  "csv",
+ "flate2",
  "itertools",
  "log",
  "log4rs",
@@ -1639,6 +1651,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "xz2",
 ]
 
 [[package]]
@@ -1803,6 +1816,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ thiserror = "1.0.50"
 anyhow = "1.0.75"
 minijinja = "1.0.15"
 clap_complete = "4.5.1"
+xz2 = "0.1.7"
+flate2 = "1.0.30"
+bzip2 = "0.4.4"
 
 [lib]
 name = "wgalib"

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Options:
   -V, --version  Print version
 
 GLOBAL:
-  -o, --outfile <OUTFILE>  Output file ("-" for stdout) [default: -]
+  -o, --outfile <OUTFILE>  Output file ("-" for stdout), file name ending in .gz/.bz2/.xz will be compressed automatically [default: -]
   -r, --rewrite            Bool, if rewrite output file [default: false]
   -t, --threads <THREADS>  Threads, default 1 [default: 1]
   -v, --verbose...         Logging level [-v: Info, -vv: Debug, -vvv: Trace, defalut: Warn]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@ help_template =
 ) // change template more!
 ]
 pub struct Cli {
-    /// Output file ("-" for stdout)
+    /// Output file ("-" for stdout), file name ending in .gz/.bz2/.xz will be compressed automatically
     #[arg(long, short, global = true, default_value = "-", help_heading = Some("GLOBAL"))]
     pub outfile: String,
     /// Bool, if rewrite output file [default: false]


### PR DESCRIPTION
-  Support for reading and writing gzip, xz, and bzip2 compressed files. 
-  Compression is applied automatically based on the file extension during output.
- The compression level for the output file is hardcoded as 6. It would be more flexible if you could set it as a parameter.
