### PR TITLE
add gzip/xz/bzip2 support for IO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,9 +465,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1620,10 +1630,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
+ "bzip2",
  "clap",
  "clap_complete",
  "crossterm",
  "csv",
+ "flate2",
  "itertools",
  "log",
  "log4rs",
@@ -1639,6 +1651,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "xz2",
 ]
 
 [[package]]
@@ -1803,6 +1816,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ thiserror = "1.0.50"
 anyhow = "1.0.75"
 minijinja = "1.0.15"
 clap_complete = "4.5.1"
+xz2 = "0.1.7"
+flate2 = "1.0.30"
+bzip2 = "0.4.4"
 
 [lib]
 name = "wgalib"

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Options:
   -V, --version  Print version
 
 GLOBAL:
-  -o, --outfile <OUTFILE>  Output file ("-" for stdout) [default: -]
+  -o, --outfile <OUTFILE>  Output file ("-" for stdout), file name ending in .gz/.bz2/.xz will be compressed automatically [default: -]
   -r, --rewrite            Bool, if rewrite output file [default: false]
   -t, --threads <THREADS>  Threads, default 1 [default: 1]
   -v, --verbose...         Logging level [-v: Info, -vv: Debug, -vvv: Trace, defalut: Warn]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@ help_template =
 ) // change template more!
 ]
 pub struct Cli {
-    /// Output file ("-" for stdout)
+    /// Output file ("-" for stdout), file name ending in .gz/.bz2/.xz will be compressed automatically
     #[arg(long, short, global = true, default_value = "-", help_heading = Some("GLOBAL"))]
     pub outfile: String,
     /// Bool, if rewrite output file [default: false]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,13 +24,19 @@ use crate::{
 use clap::CommandFactory;
 use clap_complete::{generate, Shell};
 use log::{info, warn};
-use std::{io::{stdin, stdout, BufRead, BufReader, BufWriter, Stdin, Write}, path};
+use std::io::{stdin, stdout, BufRead, BufReader, BufWriter, Read, Stdin, Write};
 use std::path::Path;
 use std::{fs::File, path::PathBuf};
 
 // TODO : define a pub type WResult = Result<(), WGAError>;
 
 const BUFFER_SIZE: usize = 32 * 1024;
+
+const MAGIC_MAX_LEN: usize = 6;
+// compressed file magic number, ref: https://docs.rs/infer/latest/infer/archive/index.html
+const GZ_MAGIC: [u8; 3] = [0x1f, 0x8b, 0x08];
+const BZ_MAGIC: [u8; 3] = [0x42, 0x5a, 0x68];
+const XZ_MAGIC: [u8; 6] = [0xfd, 0x37, 0x7a, 0x58, 0x5A, 0x00];
 
 type RdrWtr = (Box<dyn BufRead + Send>, Box<dyn Write>);
 fn prepare_rdr_wtr(
@@ -92,30 +98,65 @@ pub fn reverse_complement(input: &str) -> Result<String, WGAError> {
     Ok(output)
 }
 
+fn get_magic_num(path: &str) -> Result<[u8; MAGIC_MAX_LEN], WGAError> {
+    let mut buffer: [u8; MAGIC_MAX_LEN] = [0; MAGIC_MAX_LEN];
+    let mut fp = File::open(path)?;
+    let _ = fp.read(&mut buffer)?;
+    Ok(buffer)
+}
+
+fn is_gzipped(path: &str) -> Result<bool, WGAError> {
+    let buffer = get_magic_num(path)?;
+    let gz_or_not =
+        buffer[0] == GZ_MAGIC[0] && buffer[1] == GZ_MAGIC[1] && buffer[2] == GZ_MAGIC[2];
+    Ok(gz_or_not || Path::new(path).extension().is_some_and(|ext| ext == "gz"))
+}
+
+fn is_bzipped(path: &str) -> Result<bool, WGAError> {
+    let buffer = get_magic_num(path)?;
+    let bz_or_not =
+        buffer[0] == BZ_MAGIC[0] && buffer[1] == BZ_MAGIC[1] && buffer[2] == BZ_MAGIC[2];
+    Ok(bz_or_not || Path::new(path).extension().is_some_and(|ext| ext == "bz2"))
+}
+
+fn is_xz(path: &str) -> Result<bool, WGAError> {
+    let buffer = get_magic_num(path)?;
+    let xz_or_not = buffer[0] == XZ_MAGIC[0]
+        && buffer[1] == XZ_MAGIC[1]
+        && buffer[2] == XZ_MAGIC[2]
+        && buffer[3] == XZ_MAGIC[3]
+        && buffer[4] == XZ_MAGIC[4]
+        && buffer[5] == XZ_MAGIC[5];
+    Ok(xz_or_not || Path::new(path).extension().is_some_and(|ext| ext == "xz"))
+}
+
 pub fn get_input_reader(input: &Option<String>) -> Result<Box<dyn BufRead + Send>, WGAError> {
-    let reader: Box<dyn BufRead + Send> = if let Some(path)  = input {
-        
+    let reader: Box<dyn BufRead + Send> = if let Some(path) = input {
         match File::open(path) {
             Ok(file) => {
-                if Path::new(path).extension().is_some_and(|ext| ext == "xz") {
+                if is_xz(path)? {
                     // decode xz compressed file
-                    Box::new( 
-                        BufReader::with_capacity(BUFFER_SIZE, xz2::read::XzDecoder::new_multi_decoder(file)) 
-                    )
-                } else if Path::new(path).extension().is_some_and(|ext| ext == "gz") {
+                    Box::new(BufReader::with_capacity(
+                        BUFFER_SIZE,
+                        xz2::read::XzDecoder::new_multi_decoder(file),
+                    ))
+                } else if is_gzipped(path)? {
                     // decode gzip compressed file
-                    Box::new(
-                        BufReader::with_capacity(BUFFER_SIZE, flate2::read::MultiGzDecoder::new(file))
-                    )
-                } else if Path::new(path).extension().is_some_and(|ext| ext == "bz2") {
+                    Box::new(BufReader::with_capacity(
+                        BUFFER_SIZE,
+                        flate2::read::MultiGzDecoder::new(file),
+                    ))
+                } else if is_bzipped(path)? {
                     // decode bzip2 compressed file
-                    Box::new(
-                        BufReader::with_capacity(BUFFER_SIZE, bzip2::read::MultiBzDecoder::new(file))
-                    )
-                } else { // stdin flag "-" covered
+                    Box::new(BufReader::with_capacity(
+                        BUFFER_SIZE,
+                        bzip2::read::MultiBzDecoder::new(file),
+                    ))
+                } else {
+                    // stdin flag "-" covered
                     Box::new(BufReader::with_capacity(BUFFER_SIZE, file))
                 }
-            },
+            }
             Err(_) => return Err(WGAError::FileNotExist(PathBuf::from(path))),
         }
     } else {
@@ -137,35 +178,45 @@ fn stdin_reader() -> Result<Stdin, WGAError> {
 
 fn get_output_writer(outputpath: &str, rewrite: bool) -> Result<Box<dyn Write>, WGAError> {
     check_outfile(outputpath, rewrite)?;
-    
+
     let file = File::create(outputpath)?;
     let compression_level: u32 = 6;
 
-    let writer: Box<dyn Write> = if Path::new(outputpath).extension().is_some_and(|ext| ext == "xz") {
+    let writer: Box<dyn Write> = if Path::new(outputpath)
+        .extension()
+        .is_some_and(|ext| ext == "xz")
+    {
         // encode file to xz format
-        Box::new(
-            BufWriter::with_capacity(BUFFER_SIZE,xz2::write::XzEncoder::new(file, compression_level))
-        )
-    } else if Path::new(outputpath).extension().is_some_and(|ext| ext == "gz") {
+        Box::new(BufWriter::with_capacity(
+            BUFFER_SIZE,
+            xz2::write::XzEncoder::new(file, compression_level),
+        ))
+    } else if Path::new(outputpath)
+        .extension()
+        .is_some_and(|ext| ext == "gz")
+    {
         // encode file to gzip format
-        Box::new(
-            BufWriter::with_capacity(BUFFER_SIZE, flate2::write::GzEncoder::new(file, flate2::Compression::new(compression_level)))
-        )
-    } else if Path::new(outputpath).extension().is_some_and(|ext| ext == "bz2") {
+        Box::new(BufWriter::with_capacity(
+            BUFFER_SIZE,
+            flate2::write::GzEncoder::new(file, flate2::Compression::new(compression_level)),
+        ))
+    } else if Path::new(outputpath)
+        .extension()
+        .is_some_and(|ext| ext == "bz2")
+    {
         // encode file to bzip2 format
-        Box::new(
-            BufWriter::with_capacity(BUFFER_SIZE, bzip2::write::BzEncoder::new(file, bzip2::Compression::new(compression_level)))
-        )
+        Box::new(BufWriter::with_capacity(
+            BUFFER_SIZE,
+            bzip2::write::BzEncoder::new(file, bzip2::Compression::new(compression_level)),
+        ))
     } else {
-        Box::new(
-            BufWriter::new(stdout())
-        )
+        Box::new(BufWriter::new(stdout()))
     };
-    
+
     Ok(writer)
 }
 
-/// check if output file exists and if rewrite 
+/// check if output file exists and if rewrite
 fn check_outfile(output_file: &str, rewrite: bool) -> Result<(), WGAError> {
     // check if output file exists
     if output_file != "-" {


### PR DESCRIPTION
- Support for reading and writing gzip, xz, and bzip2 compressed files.
- Compression is applied automatically based on the file extension during output.
- The compression level for the output file is hardcoded as 6. It would be more flexible if you could set it as a parameter.