### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wgatools"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgatools"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["Wenjie Wei <wjwei9908@gmail.com>",]
 


### PR DESCRIPTION
You have made some really helpful updates to `wgatools` since the most recently tagged release, and it would be great if we could rely on them in our conda recipes. Would you mind tagging a new release for the repository? That way bioconda will automatically update and host the latest version with all of your improvements. 

Feel free to close this PR in favor of updating the version to whatever you'd prefer, of course! I was just hoping this might make it more convenient 🙂 